### PR TITLE
Fix black screen between asset-images loop

### DIFF
--- a/src/view.h
+++ b/src/view.h
@@ -3,6 +3,7 @@
 #include <QWebView>
 #include <QWebPage>
 #include <QWidget>
+#include <QEventLoop>
 
 class View : public QWebView
 {
@@ -16,4 +17,7 @@ public:
 
 private slots:
     void handleAuthRequest(QNetworkReply*, QAuthenticator*);
+private:
+    QWebPage* pre_loader;
+    QEventLoop pre_loader_loop;
 };


### PR DESCRIPTION
When use `::loadImage()` ScreenlyWebview have a black screen.
This problem is related with `::setHtml()` and that js-script running when page a full loaded.
If remove only `onload` from js-script, we see the image rendering.
Also `::setPage()` did not give the desired results.

Changes from commit work well for me. I do not longer see black screens and no the image rendering.

@vpetersson What you think about these edits?